### PR TITLE
Fix non-ASCII character in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 import os
 
-descr = """Crab is a ﬂexible, fast recommender engine for Python. The engine
+descr = """Crab is a flexible, fast recommender engine for Python. The engine
   aims to provide a rich set of components from which you can construct a
   customized recommender system from a set of algorithms."""
 


### PR DESCRIPTION
As `setup.py` does not define a file-specific encoding, it's encoding defaults to ASCII (per [PEP-236](http://www.python.org/dev/peps/pep-0263/)). The `descr` string in `setup.py` contains the non-ASCII ligature `ﬂ`, so executing `setup.py` results in `SyntaxError: Non-ASCII character '\xef' in file ...`. The attached patch fixes that by replacing the ligature with two separate glyphs.
