### PR TITLE
Fixes problems with BaseEstimator class deprecated import _set_param and Implements a hybrid method combining Collaborative Filtering and Global Baseline estimates to deal with cold start

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
   to provide a rich set of components from which you can construct a customized recommender system from a 
   set of algorithms.
 
+  In this fork, I (gabrielspmoreira) have done the following changes:
+  * Fixed some issues for compatibility with scikit.learn last version (BaseEstimator class deprecated import (scikits.learn.base) and _set_param renamed method)
+  * Implemented a hybrid method to combine Collaborative Filtering with Global Baseline estimates (based on users and items average preference), inspired on [Implementing Collaborative Filtering class](https://class.coursera.org/mmds-001/lecture/95) from [Coursera Mining Massive Datasets course](https://www.coursera.org/course/mmds).
+
 ## Usage
 
   For Usage and Instructions checkout the [Crab Wiki](https://github.com/muricoca/crab/wiki)
@@ -14,7 +18,7 @@
   The project was started in 2010  by Marcel Caraciolo as a M.S.C related  project, and since then many people interested joined to help in the project.
   It is currently maintained by a team of volunteers, members of the Muriçoca Labs.
 
-## Authors
+## Original Authors
   
   Marcel Caraciolo (marcel@muricoca.com)
 

--- a/scikits/crab/base.py
+++ b/scikits/crab/base.py
@@ -8,7 +8,7 @@ Base Recommender Models.
 #          Bruno Melo <bruno@muricoca.com>
 # License: BSD Style.
 
-from scikits.learn.base import BaseEstimator
+from sklearn.base import BaseEstimator
 
 
 class BaseRecommender(BaseEstimator):

--- a/scikits/crab/metrics/classes.py
+++ b/scikits/crab/metrics/classes.py
@@ -21,7 +21,7 @@ from metrics import precision_score
 from metrics import recall_score
 from metrics import f1_score
 from sampling import SplitSampling
-from scikits.learn.base import clone
+from sklearn.base import clone
 from ..models.utils import ItemNotFoundError, UserNotFoundError
 
 

--- a/scikits/crab/recommenders/knn/classes.py
+++ b/scikits/crab/recommenders/knn/classes.py
@@ -135,7 +135,7 @@ class ItemBasedRecommender(ItemRecommender):
                  Desired number of recommendations (default=None ALL)
 
         '''
-        self._set_params(**params)
+        self.set_params(**params)
 
         candidate_items = self.all_other_items(user_id)
 
@@ -597,7 +597,7 @@ class UserBasedRecommender(UserRecommender):
 
         '''
 
-        self._set_params(**params)
+        self.set_params(**params)
 
         candidate_items = self.all_other_items(user_id, **params)
 

--- a/scikits/crab/recommenders/svd/classes.py
+++ b/scikits/crab/recommenders/svd/classes.py
@@ -286,7 +286,7 @@ class MatrixFactorBasedRecommender(SVDRecommender):
                  Desired number of recommendations (default=None ALL)
 
         '''
-        self._set_params(**params)
+        self.set_params(**params)
 
         candidate_items = self.all_other_items(user_id)
 


### PR DESCRIPTION
- Fixes problems with BaseEstimator class deprecated import (scikits.learn.base) (Issue #90 ) and _set_param renamed method (Issue #94  ) making it compatible to the last stable scikit-learn version '0.15.2'
- Implemented a hybrid method to combine Collaborative Filtering with Global Baseline estimates (based on users and items average preference), to deal with users and items cold start, inspired on [Implementing Collaborative Filtering class](https://class.coursera.org/mmds-001/lecture/95) from [Coursera Mining Massive Datasets course](https://www.coursera.org/course/mmds).
