### PR TITLE
docs: fix simple typo, distrance -> distance

### DIFF
--- a/scikits/crab/metrics/pairwise.py
+++ b/scikits/crab/metrics/pairwise.py
@@ -45,7 +45,7 @@ def euclidean_distances(X, Y, squared=False, inverse=True):
     --------
     >>> from scikits.crab.metrics.pairwise import euclidean_distances
     >>> X = [[2.5, 3.5, 3.0, 3.5, 2.5, 3.0],[3.0, 3.5, 1.5, 5.0, 3.5,3.0]]
-    >>> # distrance between rows of X
+    >>> # distance between rows of X
     >>> euclidean_distances(X, X)
     array([[ 1.        ,  0.29429806],
            [ 0.29429806,  1.        ]])


### PR DESCRIPTION
There is a small typo in scikits/crab/metrics/pairwise.py.

Should read `distance` rather than `distrance`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md